### PR TITLE
Fix activeEditable === null errors for commands (FF)

### DIFF
--- a/ng-aloha-editor.js
+++ b/ng-aloha-editor.js
@@ -171,7 +171,8 @@ module.directive('aloha', ['$location', '$rootScope', function ($location, $root
                 });
 
                 Aloha.bind('aloha-selection-changed', function (jQueryEvent, alohaEditable) {
-                    if (jQueryEvent.target.activeEditable.originalObj[0].id == elem.attr('id')) {
+                    var ae = jQueryEvent.target.activeEditable;
+                    if (ae && ae.originalObj[0].id === elem.attr('id')) {
                         /**
                         * The Text Editor has detected a change in it's selection
                         * @event texteditor-selection-changed
@@ -183,7 +184,8 @@ module.directive('aloha', ['$location', '$rootScope', function ($location, $root
                 });
 
                 Aloha.bind('aloha-editable-deactivated', function(jQueryEvent, alohaEditable) {
-                    if (jQueryEvent.target.activeEditable.originalObj[0].id == elem.attr('id')) {
+                    var ae = jQueryEvent.target.activeEditable;
+                    if (ae && ae.originalObj[0].id === elem.attr('id')) {
                         /**
                         * The Text Editor had deactivated editability
                         * @event texteditor-editable-deactivated
@@ -195,10 +197,12 @@ module.directive('aloha', ['$location', '$rootScope', function ($location, $root
                 });
 
                 Aloha.bind('aloha-smart-content-changed', function(jQueryEvent, alohaEditable) {
+                    var ae = jQueryEvent.target.activeEditable;
+
                     // Reset {bool} fromAloha to the false state
                     fromAloha = false;
 
-                    if (jQueryEvent.target.activeEditable.originalObj[0].id == elem.attr('id')) {
+                    if (ae && ae.originalObj[0].id === elem.attr('id')) {
                         scope.alohaContent = alohaEditable.editable.getContents();
                         fromAloha = true;
                         $rootScope.$$phase || $rootScope.$apply();
@@ -214,7 +218,8 @@ module.directive('aloha', ['$location', '$rootScope', function ($location, $root
                 });
 
                 Aloha.bind('aloha-command-executed', function(jQueryEvent, eventArgument) {
-                    if (jQueryEvent.target.activeEditable.originalObj[0].id == elem.attr('id')) {
+                    var ae = jQueryEvent.target.activeEditable;
+                    if (ae && ae.originalObj[0].id === elem.attr('id')) {
                         /**
                         * The Text Editor has executed a command
                         * @event texteditor-command-executed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-aloha-editor",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Executing editor actions (e.g. bold, italic...) in Firefox (and perhaps elsewhere, too) is not reliable, as sometimes the activeAditable is null and an error is thrown. This PR fixes this by adding additional checks.
